### PR TITLE
Parse when number is really tiny

### DIFF
--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -334,3 +334,44 @@ export async function validateStorageAccountType(
         }
     }
 }
+
+export function parseScientific(num: string): string {
+    // If the number is not in scientific notation return it as it is.
+    if (!/\d+\.?\d*e[+-]*\d+/i.test(num)) {
+        return num;
+    }
+
+    // Remove the sign.
+    const numberSign = Math.sign(Number(num));
+    num = Math.abs(Number(num)).toString();
+
+    // Parse into coefficient and exponent.
+    const [coefficient, exponent] = num.toLowerCase().split("e");
+    let zeros = Math.abs(Number(exponent));
+    const exponentSign = Math.sign(Number(exponent));
+    const [integer, decimals] = (
+        coefficient.indexOf(".") != -1 ? coefficient : `${coefficient}.`
+    ).split(".");
+
+    if (exponentSign === -1) {
+        zeros -= integer.length;
+        num =
+            zeros < 0
+                ? integer.slice(0, zeros) +
+                  "." +
+                  integer.slice(zeros) +
+                  decimals
+                : "0." + "0".repeat(zeros) + integer + decimals;
+    } else {
+        if (decimals) zeros -= decimals.length;
+        num =
+            zeros < 0
+                ? integer +
+                  decimals.slice(0, zeros) +
+                  "." +
+                  decimals.slice(zeros)
+                : integer + decimals + "0".repeat(zeros);
+    }
+
+    return numberSign < 0 ? "-" + num : num;
+}

--- a/src/shdw-drive.ts
+++ b/src/shdw-drive.ts
@@ -17,6 +17,7 @@ import {
     getStorageConfigPDA,
     humanSizeToBytes,
     loadWalletKey,
+    parseScientific,
     sortByProperty,
     validateStorageAccount,
 } from "./helpers";
@@ -104,8 +105,10 @@ programCommand("create-storage-account")
         const accountCostEstimate = storageInputBigInt
             .mul(shadesPerGib)
             .div(bytesPerGib);
-        const accountCostUiAmount = accountCostEstimate.toNumber() / 10 ** 9;
-        // log.info(`This account will require ${accountCostEstimate} SHDW to setup`);
+        const accountCostUiAmount = parseScientific(
+            (accountCostEstimate / new anchor.BN(10 ** 9)).toString()
+        );
+
         const confirmStorageCost = await prompts({
             type: "confirm",
             name: "acceptStorageCost",


### PR DESCRIPTION
When a number is really tiny and can only be expressed in scientific notation, we can parse that back into a string with the correct decimal places. Resolves #5 